### PR TITLE
Scope keymaps to Cucumber-related syntaxes

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,4 +1,4 @@
 [
-  { "keys": ["alt+;"], "command": "table_cleaner" },
-  { "keys": ["alt+shift+;"], "command": "table_import" }
+  { "keys": ["alt+;"], "command": "table_cleaner", "context": [{"key": "selector", "operator": "equal", "operand": "source.ruby.rspec.cucumber.steps,text.gherkin.feature"}] },
+  { "keys": ["alt+shift+;"], "command": "table_import", "context": [{"key": "selector", "operator": "equal", "operand": "source.ruby.rspec.cucumber.steps,text.gherkin.feature"}] }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,4 +1,4 @@
 [
-  { "keys": ["alt+;"], "command": "table_cleaner" },
-  { "keys": ["alt+shift+;"], "command": "table_import" }
+  { "keys": ["alt+;"], "command": "table_cleaner", "context": [{"key": "selector", "operator": "equal", "operand": "source.ruby.rspec.cucumber.steps,text.gherkin.feature"}] },
+  { "keys": ["alt+shift+;"], "command": "table_import", "context": [{"key": "selector", "operator": "equal", "operand": "source.ruby.rspec.cucumber.steps,text.gherkin.feature"}] }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,4 +1,4 @@
 [
-  { "keys": ["alt+;"], "command": "table_cleaner" },
-  { "keys": ["alt+shift+;"], "command": "table_import" }
+  { "keys": ["alt+;"], "command": "table_cleaner", "context": [{"key": "selector", "operator": "equal", "operand": "source.ruby.rspec.cucumber.steps,text.gherkin.feature"}] },
+  { "keys": ["alt+shift+;"], "command": "table_import", "context": [{"key": "selector", "operator": "equal", "operand": "source.ruby.rspec.cucumber.steps,text.gherkin.feature"}] }
 ]


### PR DESCRIPTION
Hey Drew!

This fix avoids conflicts with various platform-native keyboard mappings. For instance, on OSX with an FR keyboard, `alt+;` produces an ellipsis (`…`) and `alt+shift+;` is a middot (`•`), which typography fans (such as myself) want to retain in most of their files.

It's fine if you reserve such mappings in Cucumber contexts, but I want that in my Markdown, etc. :smile:

Also, generally ST favors keymap scoping to avoid conflicts with other ST keymaps.

Best,