### PR TITLE
Fixed indentation for autocompletion. Fixes #18

### DIFF
--- a/GherkinAutoComplete.py
+++ b/GherkinAutoComplete.py
@@ -137,7 +137,7 @@ class GherkinAutoComplete(GherkinPhrases, sublime_plugin.EventListener):
             completions = self.get_autocomplete_list(
                 prefix or search, predicate=predicate)
 
-        return (completions, sublime.INHIBIT_EXPLICIT_COMPLETIONS | sublime.INHIBIT_WORD_COMPLETIONS)
+            return (completions, sublime.INHIBIT_EXPLICIT_COMPLETIONS | sublime.INHIBIT_WORD_COMPLETIONS)
 
     def index_file(self, file_name):
         print('Indexing gherkin phrases in ' + file_name)


### PR DESCRIPTION
Our autocompletion is being too aggressive. It is completing for *all* files, not only Cucumber files. This is due to returning in all cases. It looks like by moving the `return` block into the `if` statement that ST2 starts working again.